### PR TITLE
set gpg-agent default ttl

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,11 @@ description: "Import private GPG key"
 runs:
   using: "composite"
   steps:
+    - id: set-default-cache-ttl
+      run: |
+        gpg-agent --daemon --default-cache-ttl 7200
+      shell: bash
+      name: set default cache ttl
     - run: |
         #
         echo -e "${{ env.GPG_PRIVATE_KEY }}" | gpg --import --batch --no-tty


### PR DESCRIPTION
Upping the gpg-agent default cache ttl (from default 600 secs/10 mins) so that we don't have to re-enter the passphrase in subsequent (goreleaser) signing steps.